### PR TITLE
Add reset and editing features

### DIFF
--- a/app.py
+++ b/app.py
@@ -73,6 +73,35 @@ def create_prompt():
     prompt['_id'] = str(result.inserted_id)
     return jsonify(prompt)
 
+@app.route('/api/prompts/<pid>', methods=['GET'])
+def get_prompt(pid):
+    prompt = prompts_col.find_one({'_id': ObjectId(pid)})
+    if not prompt:
+        return '', 404
+    prompt['_id'] = str(prompt['_id'])
+    return jsonify(prompt)
+
+@app.route('/api/prompts/<pid>', methods=['PUT'])
+def update_prompt(pid):
+    data = request.get_json()
+    user_id = data.get('userId')
+    prompt = prompts_col.find_one({'_id': ObjectId(pid)})
+    if not prompt:
+        return '', 404
+    if prompt.get('userId') != user_id:
+        return '', 403
+    allowed = ['text', 'businessType', 'summary', 'result']
+    update = {k: data[k] for k in allowed if k in data}
+    if not update:
+        return '', 400
+    result = prompts_col.find_one_and_update(
+        {'_id': ObjectId(pid)},
+        {'$set': update},
+        return_document=True
+    )
+    result['_id'] = str(result['_id'])
+    return jsonify(result)
+
 @app.route('/api/prompts/<pid>/like', methods=['POST'])
 def like_prompt(pid):
     data = request.get_json()

--- a/public/index.html
+++ b/public/index.html
@@ -6,18 +6,20 @@
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body class="container py-4">
-<nav class="mb-4">
-  <div class="d-flex justify-content-between align-items-center">
-    <h2 id="siteName">Prompt Share</h2>
-    <div>
-      <a href="/post" id="postBtn" class="btn btn-success">投稿</a>
-      <button class="btn btn-outline-secondary" onclick="logout()">ログアウト</button>
+<div class="sticky-top bg-white pb-2">
+  <nav class="mb-2">
+    <div class="d-flex justify-content-between align-items-center">
+      <h2 id="siteName" style="cursor:pointer">Prompt Share</h2>
+      <div>
+        <a href="/post" id="postBtn" class="btn btn-success">投稿</a>
+        <button class="btn btn-outline-secondary" onclick="logout()">ログアウト</button>
+      </div>
     </div>
+  </nav>
+  <div class="input-group">
+    <input id="search" class="form-control" placeholder="検索">
+    <button class="btn btn-outline-primary" onclick="load()">検索</button>
   </div>
-</nav>
-<div class="input-group mb-3">
-  <input id="search" class="form-control" placeholder="検索">
-  <button class="btn btn-outline-primary" onclick="load()">検索</button>
 </div>
 <div id="prompts"></div>
 <script>
@@ -29,6 +31,11 @@ fetch('/api/config').then(r=>r.json()).then(cfg=>{
   document.title=cfg.listPageName+' - '+cfg.siteName;
   document.getElementById('siteName').textContent=cfg.siteName;
   document.getElementById('postBtn').textContent=cfg.postPageName;
+  document.getElementById('siteName').addEventListener('click',()=>{
+    document.getElementById('search').value='';
+    load();
+    window.scrollTo({top:0,behavior:'smooth'});
+  });
   load();
 });
 
@@ -52,8 +59,9 @@ async function load(){
       card.className='card mb-2';
       const cBody=document.createElement('div');
       cBody.className='card-body';
+      const editBtn=p.userId===userId?`<a href="/post?id=${p._id}" class="btn btn-sm btn-outline-primary float-end ms-2"><span class='bi bi-pencil'></span></a>`:'';
       const delBtn=p.userId===userId?`<button class="btn btn-sm btn-danger float-end" onclick="delPrompt('${p._id}')"><span class='bi bi-trash'></span></button>`:'';
-      cBody.innerHTML=`<h5 class='card-title'>${p.text}${delBtn}</h5><p class='card-text'>${p.summary}<br>${p.result}<br><small class='text-muted'>By ${p.userId} - ${new Date(p.createdAt).toLocaleString()}</small></p>`;
+      cBody.innerHTML=`<h5 class='card-title'>${p.text}${delBtn}${editBtn}</h5><p class='card-text'>${p.summary}<br>${p.result}<br><small class='text-muted'>By ${p.userId} - ${new Date(p.createdAt).toLocaleString()}</small></p>`;
       const likeBtn=document.createElement('button');
       likeBtn.className='btn btn-outline-primary btn-sm me-2';
       likeBtn.innerHTML=`👍 ${p.likes}`;

--- a/public/post.html
+++ b/public/post.html
@@ -20,19 +20,31 @@
   <div class="mb-3">
     <textarea id="presult" class="form-control" rows="3" placeholder="得られる結果" required></textarea>
   </div>
-  <button type="submit" class="btn btn-primary">登録</button>
+  <button id="submitBtn" type="submit" class="btn btn-primary">登録</button>
   <a href="/prompts" class="btn btn-secondary ms-2">戻る</a>
 </form>
 <script>
 const userId=localStorage.getItem('userId');
 if(!userId){location.href='/';}
 let CONFIG={};
+const params=new URLSearchParams(location.search);
+const editId=params.get('id');
 fetch('/api/config').then(r=>r.json()).then(cfg=>{
   CONFIG=cfg;
   document.title=cfg.postPageName+' - '+cfg.siteName;
   document.getElementById('heading').textContent=cfg.postPageName;
   const sel=document.getElementById('ptype');
   cfg.categories.forEach(c=>{const opt=document.createElement('option');opt.value=c;opt.textContent=c;sel.appendChild(opt);});
+  if(editId){
+    document.getElementById('heading').textContent='プロンプト編集';
+    document.getElementById('submitBtn').textContent='更新';
+    fetch('/api/prompts/'+editId).then(r=>r.json()).then(p=>{
+      document.getElementById('ptext').value=p.text;
+      document.getElementById('ptype').value=p.businessType;
+      document.getElementById('psummary').value=p.summary;
+      document.getElementById('presult').value=p.result;
+    });
+  }
 });
 
 document.getElementById('form').addEventListener('submit',async e=>{
@@ -42,13 +54,20 @@ document.getElementById('form').addEventListener('submit',async e=>{
     businessType:document.getElementById('ptype').value,
     summary:document.getElementById('psummary').value,
     result:document.getElementById('presult').value,
-    userId,
-    createdAt:new Date().toISOString(),
-    likes:0,
-    comments:[]
+    userId
   };
+  let url='/api/prompts';
+  let method='POST';
+  if(editId){
+    url='/api/prompts/'+editId;
+    method='PUT';
+  }else{
+    p.createdAt=new Date().toISOString();
+    p.likes=0;
+    p.comments=[];
+  }
   try{
-    const res=await fetch('/api/prompts',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(p)});
+    const res=await fetch(url,{method,headers:{'Content-Type':'application/json'},body:JSON.stringify(p)});
     if(res.ok){
       location.href='/prompts';
     }else{


### PR DESCRIPTION
## Summary
- fix header position on list page and enable reset by clicking the title
- allow editing own prompts via new icon and edit screen
- support fetching/updating a prompt on the backend

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_6878985ddfa483338d4aaf96c5d03609